### PR TITLE
Fix broken Chaos Mode link

### DIFF
--- a/chaos_build_package/README.md
+++ b/chaos_build_package/README.md
@@ -34,6 +34,19 @@ curl https://your-app.onrender.com/8ball
 🎱 Error 418: Teapot detected.
 ```
 
+### 3. **Chaos Mode** (`/8ball/chaos` endpoint)
+Even less reliable wisdom for the brave.
+
+**Sample query:**
+```bash
+curl https://your-app.onrender.com/8ball/chaos
+```
+
+**Sample response:**
+```
+🎱 The simulation is glitching... try again later.
+```
+
 ---
 
 ## 🚨 TOASTER TROUBLESHOOTING

--- a/chaos_build_package/app.py
+++ b/chaos_build_package/app.py
@@ -59,5 +59,16 @@ def eight_ball():
     ]
     return f"🎱 {random.choice(answers)}"
 
+@app.route('/8ball/chaos')
+def eight_ball_chaos():
+    chaotic_answers = [
+        "The simulation is glitching... try again later.",
+        "All signs point to cosmic spaghetti.",
+        "42, but only on Tuesdays.",
+        "Your guess is as good as mine.",
+        "Proceed with extreme caution!"
+    ]
+    return f"🎱 {random.choice(chaotic_answers)}"
+
 if __name__ == '__main__':
     app.run()

--- a/toaster_ui_final/app.py
+++ b/toaster_ui_final/app.py
@@ -59,5 +59,16 @@ def eight_ball():
     ]
     return f"🎱 {random.choice(answers)}"
 
+@app.route('/8ball/chaos')
+def eight_ball_chaos():
+    chaotic_answers = [
+        "The simulation is glitching... try again later.",
+        "All signs point to cosmic spaghetti.",
+        "42, but only on Tuesdays.",
+        "Your guess is as good as mine.",
+        "Proceed with extreme caution!"
+    ]
+    return f"🎱 {random.choice(chaotic_answers)}"
+
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
## Summary
- add missing `/8ball/chaos` route
- expose chaos mode in README

## Testing
- `python -m py_compile chaos_build_package/app.py toaster_ui_final/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685c8776f4dc83339026be08d4fdd323